### PR TITLE
#2 Update README for rt-tab-carousel with mention of specific bug related to the same UUID providing [RT Tab Carousel]

### DIFF
--- a/projects/rt-tab-carousel/README.md
+++ b/projects/rt-tab-carousel/README.md
@@ -35,10 +35,10 @@ Use for a ready-made container in which all the items lie
 
 ``rtCarouselTab``
 
-| Option           | Default        | Type  | Description                                                                                                            |
-|------------------|----------------|-------|------------------------------------------------------------------------------------------------------------------------|
-| **disabledTab**  | false          | Input |                                                                                                                        |
-| **uuidCarousel** | null *required | Input | This is a required property that indicates ownership and creates relationships between controls, containers, and items |
+| Option           | Default        | Type  | Description                                                                                                                                                                                                                                                                                                                                                                |
+|------------------|----------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **disabledTab**  | false          | Input |                                                                                                                                                                                                                                                                                                                                                                            |
+| **uuidCarousel** | null *required | Input | This is a required property that indicates ownership and creates relationships between controls, containers, and items. Please, take note, that applying the same UUID to the different carousels will cause a specific behavior: the service will treat them as the same item that will cause arrows to appear on every navigation no matter the real content visibility  |
 
 ``rtCarouselNextButton``
 ``rtCarouselPreviousButton``

--- a/src/assets/rt-tab-carousel/README.md
+++ b/src/assets/rt-tab-carousel/README.md
@@ -1,5 +1,9 @@
 # RT-TAB-CAROUSEL
 
+![](/projects/rt-tab-carousel/rt-carousel_1.gif)
+![](/projects/rt-tab-carousel/rt-carousel_2.gif)
+
+
 ## Install
 
 ```bash
@@ -11,6 +15,9 @@ or
 ```bash
 npm install rt-tab-carousel
 ```
+
+
+
 
 
 ``rtCarouselContainer``
@@ -28,10 +35,10 @@ Use for a ready-made container in which all the items lie
 
 ``rtCarouselTab``
 
-| Option           | Default        | Type  | Description                                                                                                            |
-|------------------|----------------|-------|------------------------------------------------------------------------------------------------------------------------|
-| **disabledTab**  | false          | Input |                                                                                                                        |
-| **uuidCarousel** | null *required | Input | This is a required property that indicates ownership and creates relationships between controls, containers, and items |
+| Option           | Default        | Type  | Description                                                                                                                                                                                                                                                                                                                                                                |
+|------------------|----------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **disabledTab**  | false          | Input |                                                                                                                                                                                                                                                                                                                                                                            |
+| **uuidCarousel** | null *required | Input | This is a required property that indicates ownership and creates relationships between controls, containers, and items. Please, take note, that applying the same UUID to the different carousels will cause a specific behavior: the service will treat them as the same item that will cause arrows to appear on every navigation no matter the real content visibility  |
 
 ``rtCarouselNextButton``
 ``rtCarouselPreviousButton``


### PR DESCRIPTION
It was a problem with component usage, not with the component logic. We need to assign different UUIDs to different carousels if we want to treat them as different elements